### PR TITLE
Add output-file

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -27,7 +27,6 @@ runs:
       run: |
         set +e
         cd "${GITHUB_WORKSPACE}"
-        mkdir output
         if [ -z ${{ inputs.config }} ]; then
           export CONFIG=""
         else

--- a/action.yml
+++ b/action.yml
@@ -7,10 +7,10 @@ inputs:
   config:
     description: 'Path to config file'
     required: false
-outputs:
-  lint-txt:
-    description: 'Output from linting'
-    value: ${{ steps.lint.outputs.lint-txt }}
+  output-file:
+    description: 'Filename to store output.  Default "output/kubelinter.log"'
+    required: false
+    default: 'output/kubelinter.log'
 runs:
   using: "composite"
   steps:
@@ -22,14 +22,18 @@ runs:
         curl -s -L -o kube-linter-linux.tar.gz $LOCATION
         tar -xf kube-linter-linux.tar.gz -C "${GITHUB_WORKSPACE}/"
       shell: bash
-    - id: lint
+    - name: Lint files
+      id: lint
       run: |
+        set +e
         cd "${GITHUB_WORKSPACE}"
+        mkdir output
         if [ -z ${{ inputs.config }} ]; then
           export CONFIG=""
         else
           export CONFIG="--config ${{ inputs.config }}"
         fi
-        ./kube-linter $CONFIG lint ${{ inputs.directory }}
+        ./kube-linter $CONFIG lint ${{ inputs.directory }} 2>&1 | tee ${{ inputs.output-file }}
+        result_code=${PIPESTATUS[0]}
+        exit $result_code
       shell: bash
-

--- a/action.yml
+++ b/action.yml
@@ -8,9 +8,9 @@ inputs:
     description: 'Path to config file'
     required: false
   output-file:
-    description: 'Filename to store output.  Default "output/kubelinter.log"'
+    description: 'Filename to store output.  Default "kubelinter.log"'
     required: false
-    default: 'output/kubelinter.log'
+    default: 'kubelinter.log'
 runs:
   using: "composite"
   steps:


### PR DESCRIPTION
Added a configurable output file and removed the output variable.

Output variable was difficult -- GH actions [don't support multiline output](https://github.community/t/set-output-truncates-multiline-strings/16852) so it's necessary to escape newlines in the output; also, kube-linter output includes both single & double quotes, which made it nearly impossible to consume the output variable in further steps without doing even more escaping.  Output file seemed like the better approach.

https://github.com/stackrox/kube-linter-action/issues/3