### PR TITLE
Support passing a different output format to KubeLinter

### DIFF
--- a/.github/workflows/self-test.yml
+++ b/.github/workflows/self-test.yml
@@ -28,6 +28,15 @@ jobs:
           config: sample/.kube-linter-config.yaml
         continue-on-error: true
 
+      - name: Scan 2 - failing - SARIF output
+        uses: ./
+        with:
+          directory: sample/invalid-yaml
+          format: sarif
+          config: sample/.kube-linter-config.yaml
+          output-file: kube-linter.output.sarif
+        continue-on-error: true
+
   test-scan-windows:
     runs-on: windows-latest
     steps:
@@ -46,6 +55,15 @@ jobs:
           config: sample/.kube-linter-config.yaml
         continue-on-error: true
 
+      - name: Scan 2 - failing - JSON output
+        uses: ./
+        with:
+          directory: sample/invalid-yaml
+          format: json
+          config: sample/.kube-linter-config.yaml
+          output-file: kube-linter.output.json
+        continue-on-error: true
+
   test-scan-macos:
     runs-on: macos-latest
     steps:
@@ -62,4 +80,13 @@ jobs:
         with:
           directory: sample/invalid-yaml
           config: sample/.kube-linter-config.yaml
+        continue-on-error: true
+
+      - name: Scan 2 - failing - plain output
+        uses: ./
+        with:
+          directory: sample/invalid-yaml
+          format: plain
+          config: sample/.kube-linter-config.yaml
+          output-file: kube-linter.output.txt
         continue-on-error: true

--- a/README.md
+++ b/README.md
@@ -26,3 +26,4 @@ Workflow will fail if kube-linter detects issues. You'll find issues in the outp
 
 * `directory` (required) - path of file or directory to scan, absolute or relative to the root of the repo.
 * `config` (optional) - path to a [configuration file](https://docs.kubelinter.io/#/configuring-kubelinter) if you wish to use a non-default configuration.
+* `format` (optional) - output format. Allowed values: `json`, `plain`, `sarif`. (default is `plain`)

--- a/action.yml
+++ b/action.yml
@@ -10,6 +10,10 @@ inputs:
   config:
     description: 'Path to config file'
     required: false
+  format:
+    description: 'Output format. Allowed values: json, plain, sarif. (default is "plain")'
+    required: false
+    default: 'plain'
   output-file:
     description: 'Filename to store output.  Default "kubelinter.log"'
     required: false
@@ -46,6 +50,10 @@ runs:
         else
           CONFIG="--config ${{ inputs.config }}"
         fi
-        ./kube-linter $CONFIG lint ${{ inputs.directory }} 2>&1 | tee -a ${{ inputs.output-file }}
+        if [[ "${{ inputs.format }}" == "plain" ]]; then
+          ./kube-linter $CONFIG lint ${{ inputs.directory }} 2>&1 | tee -a ${{ inputs.output-file }}
+        else
+          ./kube-linter $CONFIG lint ${{ inputs.directory }} --format ${{ inputs.format }} | tee ${{ inputs.output-file }}
+        fi
         exit ${PIPESTATUS[0]}
       shell: bash


### PR DESCRIPTION
Hi there !

I'm creating this PR to support calling this Action with a more structured output format, other than the default `plain` format.

My use case is actually to generate [SARIF](https://docs.oasis-open.org/sarif/sarif/v2.0/sarif-v2.0.html) reports (as supported by KubeLinter), and upload them to GitHub Code Scanning. This way, GitHub would display those reports right under the Security tab of the repo, as we can see [here](https://docs.github.com/en/code-security/code-scanning/automatically-scanning-your-code-for-vulnerabilities-and-errors/managing-code-scanning-alerts-for-your-repository#about-alerts-details).

I initially thought this Action supported passing all options allowed by the KubeLinter CLI.
As a workaround, I currently manually download KubeLInter in my Workflow, run it with the right output format, then [upload the SARIF reports to GitHub Code Scanning](https://docs.github.com/en/code-security/code-scanning/integrating-with-code-scanning/uploading-a-sarif-file-to-github).

So I thought it would be great for this Action to support such feature out-of-the-box.

What do you think?

As this is my very first contribution to this repo, please do let me know if there is anything to change / adapt, particularly concerning the tests.