### PR TITLE
Allow to override output format and action fixes

### DIFF
--- a/.github/workflows/self-test.yml
+++ b/.github/workflows/self-test.yml
@@ -28,6 +28,15 @@ jobs:
           config: sample/.kube-linter-config.yaml
         continue-on-error: true
 
+      - name: Scan 2 - failing - SARIF output
+        uses: ./
+        with:
+          directory: sample/invalid-yaml
+          format: sarif
+          config: sample/.kube-linter-config.yaml
+          output-file: kube-linter.output.sarif
+        continue-on-error: true
+
   test-scan-windows:
     runs-on: windows-latest
     steps:
@@ -46,6 +55,15 @@ jobs:
           config: sample/.kube-linter-config.yaml
         continue-on-error: true
 
+      - name: Scan 2 - failing - JSON output
+        uses: ./
+        with:
+          directory: sample/invalid-yaml
+          format: json
+          config: sample/.kube-linter-config.yaml
+          output-file: kube-linter.output.json
+        continue-on-error: true
+
   test-scan-macos:
     runs-on: macos-latest
     steps:
@@ -62,4 +80,13 @@ jobs:
         with:
           directory: sample/invalid-yaml
           config: sample/.kube-linter-config.yaml
+        continue-on-error: true
+
+      - name: Scan 2 - failing - plain output
+        uses: ./
+        with:
+          directory: sample/invalid-yaml
+          format: plain
+          config: sample/.kube-linter-config.yaml
+          output-file: kube-linter.output.txt
         continue-on-error: true

--- a/.github/workflows/self-test.yml
+++ b/.github/workflows/self-test.yml
@@ -43,3 +43,33 @@ jobs:
         run: |
           echo "Verifying that kube-linter-action outcome (${{ steps.failing-scan.outcome }}) from Scan 2 is failure."
           [[ "${{ steps.failing-scan.outcome }}" == "failure" ]]
+
+  test-with-sarif-upload:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+
+      # Setup directory where github/codeql-action/upload-sarif@v1 looks up files by default.
+      - name: Create ../results directory for sarif files
+        shell: bash
+        run: mkdir -p ../results
+
+      - name: Scan 1 - should succeed
+        uses: ./
+        with:
+          directory: sample/valid-yaml
+          config: sample/.kube-linter-config.yaml
+          format: sarif
+          output-file: ../results/kube-linter-success.sarif
+
+      - name: Scan 2 - should fail
+        uses: ./
+        with:
+          directory: sample/invalid-yaml
+          config: sample/.kube-linter-config.yaml
+          format: sarif
+          output-file: ../results/kube-linter-fail.sarif
+        continue-on-error: true
+
+      - name: Upload SARIF output file to GitHub
+        uses: github/codeql-action/upload-sarif@v1

--- a/.github/workflows/self-test.yml
+++ b/.github/workflows/self-test.yml
@@ -20,7 +20,7 @@ jobs:
     steps:
       - uses: actions/checkout@v2
 
-      - name: 1 - Scan - should succeed
+      - name: Scan 1 - should succeed
         uses: ./
         with:
           directory: sample/valid-yaml
@@ -28,7 +28,8 @@ jobs:
           format: ${{ matrix.format }}
           version: ${{ matrix.version }}
 
-      - name: 2 - Scan - should fail
+      - name: Scan 2 - should fail
+        id: failing-scan
         uses: ./
         with:
           directory: sample/invalid-yaml
@@ -36,3 +37,9 @@ jobs:
           format: ${{ matrix.format }}
           version: ${{ matrix.version }}
         continue-on-error: true
+
+      - name: Verify Scan 2 should have failed
+        shell: bash
+        run: |
+          echo "Verifying that kube-linter-action outcome (${{ steps.failing-scan.outcome }}) from Scan 2 is failure."
+          [[ "${{ steps.failing-scan.outcome }}" == "failure" ]]

--- a/.github/workflows/self-test.yml
+++ b/.github/workflows/self-test.yml
@@ -10,83 +10,23 @@ on:
     branches: [ main ]
 
 jobs:
-  test-scan-linux:
-    runs-on: ubuntu-latest
+  test-scan:
+    strategy:
+      matrix:
+        os: [ ubuntu-latest, windows-latest, macos-latest ]
+    runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v2
 
-      - name: Scan 1 - succeeding
+      - name: 1 - Scan - should succeed
         uses: ./
         with:
           directory: sample/valid-yaml
           config: sample/.kube-linter-config.yaml
 
-      - name: Scan 2 - failing
+      - name: 2 - Scan - should fail
         uses: ./
         with:
           directory: sample/invalid-yaml
           config: sample/.kube-linter-config.yaml
-        continue-on-error: true
-
-      - name: Scan 2 - failing - SARIF output
-        uses: ./
-        with:
-          directory: sample/invalid-yaml
-          format: sarif
-          config: sample/.kube-linter-config.yaml
-          output-file: kube-linter.output.sarif
-        continue-on-error: true
-
-  test-scan-windows:
-    runs-on: windows-latest
-    steps:
-      - uses: actions/checkout@v2
-
-      - name: Scan 1 - succeeding
-        uses: ./
-        with:
-          directory: sample/valid-yaml
-          config: sample/.kube-linter-config.yaml
-
-      - name: Scan 2 - failing
-        uses: ./
-        with:
-          directory: sample/invalid-yaml
-          config: sample/.kube-linter-config.yaml
-        continue-on-error: true
-
-      - name: Scan 2 - failing - JSON output
-        uses: ./
-        with:
-          directory: sample/invalid-yaml
-          format: json
-          config: sample/.kube-linter-config.yaml
-          output-file: kube-linter.output.json
-        continue-on-error: true
-
-  test-scan-macos:
-    runs-on: macos-latest
-    steps:
-      - uses: actions/checkout@v2
-
-      - name: Scan 1 - succeeding
-        uses: ./
-        with:
-          directory: sample/valid-yaml
-          config: sample/.kube-linter-config.yaml
-
-      - name: Scan 2 - failing
-        uses: ./
-        with:
-          directory: sample/invalid-yaml
-          config: sample/.kube-linter-config.yaml
-        continue-on-error: true
-
-      - name: Scan 2 - failing - plain output
-        uses: ./
-        with:
-          directory: sample/invalid-yaml
-          format: plain
-          config: sample/.kube-linter-config.yaml
-          output-file: kube-linter.output.txt
         continue-on-error: true

--- a/.github/workflows/self-test.yml
+++ b/.github/workflows/self-test.yml
@@ -14,6 +14,8 @@ jobs:
     strategy:
       matrix:
         os: [ ubuntu-latest, windows-latest, macos-latest ]
+        format: [ plain, json, sarif ]
+        version: [ latest, 0.2.3 ]
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v2
@@ -23,10 +25,14 @@ jobs:
         with:
           directory: sample/valid-yaml
           config: sample/.kube-linter-config.yaml
+          format: ${{ matrix.format }}
+          version: ${{ matrix.version }}
 
       - name: 2 - Scan - should fail
         uses: ./
         with:
           directory: sample/invalid-yaml
           config: sample/.kube-linter-config.yaml
+          format: ${{ matrix.format }}
+          version: ${{ matrix.version }}
         continue-on-error: true

--- a/README.md
+++ b/README.md
@@ -26,3 +26,4 @@ Workflow will fail if kube-linter detects issues. You'll find issues in the outp
 
 * `directory` (required) - path of file or directory to scan, absolute or relative to the root of the repo.
 * `config` (optional) - path to a [configuration file](https://docs.kubelinter.io/#/configuring-kubelinter) if you wish to use a non-default configuration.
+* `format` (optional) - output format. Allowed values: `json`, `plain`, `sarif`. (default is `plain`)

--- a/README.md
+++ b/README.md
@@ -26,4 +26,4 @@ Workflow will fail if kube-linter detects issues. You'll find issues in the outp
 
 * `directory` (required) - path of file or directory to scan, absolute or relative to the root of the repo.
 * `config` (optional) - path to a [configuration file](https://docs.kubelinter.io/#/configuring-kubelinter) if you wish to use a non-default configuration.
-* `format` (optional) - output format. Allowed values: `json`, `plain`, `sarif`. (default is `plain`)
+* `format` (optional) - output format. Allowed values: `sarif`, `plain`, `json`. (default is `plain`)

--- a/README.md
+++ b/README.md
@@ -24,6 +24,10 @@ Workflow will fail if kube-linter detects issues. You'll find issues in the outp
 
 ### Parameters
 
-* `directory` (required) - path of file or directory to scan, absolute or relative to the root of the repo.
-* `config` (optional) - path to a [configuration file](https://docs.kubelinter.io/#/configuring-kubelinter) if you wish to use a non-default configuration.
-* `format` (optional) - output format. Allowed values: `sarif`, `plain`, `json`. (default is `plain`)
+| Parameter name | Required? | Description |
+| --- | --- | --- |
+| `directory` | **(required)** | Path of file or directory to scan, absolute or relative to the root of the repo. |
+| `config` | (optional) | Path to a [configuration file](https://docs.kubelinter.io/#/configuring-kubelinter) if you wish to use a non-default configuration. |
+| `format` | (optional) | Output format. Allowed values: `sarif`, `plain`, `json`. Default is `plain`. |
+| `output-file` | (optional) | Path to a file where kube-linter output will be stored. Default is `kube-linter.log`. File will be overwritten if it exists. |
+| `version` | (optional) | kube-linter release version to use, e.g. "0.2.4". The latest available version is used by default. |

--- a/action.yml
+++ b/action.yml
@@ -10,6 +10,10 @@ inputs:
   config:
     description: 'Path to config file'
     required: false
+  format:
+    description: 'Output format. Allowed values: json, plain, sarif. (default is "plain")'
+    required: false
+    default: 'plain'
   output-file:
     description: 'Filename to store output.  Default "kubelinter.log"'
     required: false
@@ -50,6 +54,10 @@ runs:
         else
           CONFIG="--config ${{ inputs.config }}"
         fi
-        ./kube-linter $CONFIG lint ${{ inputs.directory }} 2>&1 | tee -a ${{ inputs.output-file }}
+        if [[ "${{ inputs.format }}" == "plain" ]]; then
+          ./kube-linter $CONFIG lint ${{ inputs.directory }} 2>&1 | tee -a ${{ inputs.output-file }}
+        else
+          ./kube-linter $CONFIG lint ${{ inputs.directory }} --format ${{ inputs.format }} | tee ${{ inputs.output-file }}
+        fi
         exit ${PIPESTATUS[0]}
       shell: bash

--- a/action.yml
+++ b/action.yml
@@ -19,7 +19,7 @@ inputs:
     required: false
     default: 'kubelinter.log'
   version:
-    description: 'Version of kube-linter to use. Default: "latest"'
+    description: 'Version of kube-linter to use. E.g. "0.2.4". Default: "latest"'
     required: false
     default: 'latest'
 runs:

--- a/action.yml
+++ b/action.yml
@@ -38,6 +38,10 @@ runs:
         if [ "${{ inputs.version }}" != "latest" ]; then
           RELEASE_URL='https://api.github.com/repos/stackrox/kube-linter/releases/tags/${{ inputs.version }}'
         fi
+        # Although releases endpoint is available without authentication, the current github.token is still passed
+        # in order to increase the limit of 60 requests per hour per IP address to a higher value that's also counted
+        # per GitHub account.
+        # Caching is disabled in order not to receive stale responses from Varnish cache fronting GitHub API.
         RELEASE_INFO=$(curl --silent --show-error --fail \
           --header 'authorization: Bearer ${{ github.token }}' \
           --header 'Cache-Control: no-cache, must-revalidate' \

--- a/action.yml
+++ b/action.yml
@@ -35,34 +35,34 @@ runs:
           *)       OS=linux ;;
         esac
         RELEASE_URL='https://api.github.com/repos/stackrox/kube-linter/releases/latest'
-        if [ "${{ inputs.version }}" != "latest" ]; then
+        if [[ "${{ inputs.version }}" != "latest" ]]; then
           RELEASE_URL='https://api.github.com/repos/stackrox/kube-linter/releases/tags/${{ inputs.version }}'
         fi
         # Although releases endpoint is available without authentication, the current github.token is still passed
         # in order to increase the limit of 60 requests per hour per IP address to a higher value that's also counted
         # per GitHub account.
         # Caching is disabled in order not to receive stale responses from Varnish cache fronting GitHub API.
-        RELEASE_INFO=$(curl --silent --show-error --fail \
+        RELEASE_INFO="$(curl --silent --show-error --fail \
           --header 'authorization: Bearer ${{ github.token }}' \
           --header 'Cache-Control: no-cache, must-revalidate' \
-          "${RELEASE_URL}")
-        RELEASE_NAME=$(echo "${RELEASE_INFO}" | jq --raw-output ".name")
-        LOCATION=$(echo "${RELEASE_INFO}" \
+          "${RELEASE_URL}")"
+        RELEASE_NAME="$(echo "${RELEASE_INFO}" | jq --raw-output ".name")"
+        LOCATION="$(echo "${RELEASE_INFO}" \
           | jq --raw-output ".assets[].browser_download_url" \
-          | grep --fixed-strings kube-linter-${OS}.tar.gz)
-        TARGET=kube-linter-${OS}-${RELEASE_NAME}.tar.gz
+          | grep --fixed-strings "kube-linter-${OS}.tar.gz")"
+        TARGET="kube-linter-${OS}-${RELEASE_NAME}.tar.gz"
         # Skip downloading release if downloaded already, e.g. when the action is used multiple times.
-        if [ ! -e $TARGET ]; then
-          curl --silent --show-error --fail --location --output $TARGET "$LOCATION"
-          tar -xf $TARGET
+        if [[ ! -e "$TARGET" ]]; then
+          curl --silent --show-error --fail --location --output "$TARGET" "$LOCATION"
+          tar -xf "$TARGET"
         fi
     - name: Lint files
       shell: bash
       run: |
         set -u
-        if [ -z ${{ inputs.config }} ]; then
+        if [[ -z "${{ inputs.config }}" ]]; then
           CONFIG=""
         else
           CONFIG="--config ${{ inputs.config }}"
         fi
-        ./kube-linter $CONFIG lint ${{ inputs.directory }} --format ${{ inputs.format }} | tee ${{ inputs.output-file }}
+        ./kube-linter $CONFIG lint "${{ inputs.directory }}" --format "${{ inputs.format }}" | tee "${{ inputs.output-file }}"

--- a/action.yml
+++ b/action.yml
@@ -26,8 +26,9 @@ runs:
   using: "composite"
   steps:
     - name: Download kube-linter
+      shell: bash
       run: |
-        set -euo pipefail
+        set -u
         case "${{ runner.os }}" in
           macOS)   OS=darwin ;;
           Windows) OS=windows ;;
@@ -44,16 +45,15 @@ runs:
           curl --silent --show-error --fail --location --output $TARGET "$LOCATION"
           tar -xf $TARGET
         fi
-      shell: bash
     - name: Lint files
+      shell: bash
       run: |
         set -u
-        set +e
         if [ -z ${{ inputs.config }} ]; then
           CONFIG=""
         else
           CONFIG="--config ${{ inputs.config }}"
         fi
+        set +e
         ./kube-linter $CONFIG lint ${{ inputs.directory }} --format ${{ inputs.format }} | tee ${{ inputs.output-file }}
         exit ${PIPESTATUS[0]}
-      shell: bash

--- a/action.yml
+++ b/action.yml
@@ -59,4 +59,4 @@ runs:
         fi
         set +e
         ./kube-linter $CONFIG lint ${{ inputs.directory }} --format ${{ inputs.format }} | tee ${{ inputs.output-file }}
-        exit ${PIPESTATUS[0]}
+        exit "${PIPESTATUS[0]}"

--- a/action.yml
+++ b/action.yml
@@ -61,6 +61,4 @@ runs:
         else
           CONFIG="--config ${{ inputs.config }}"
         fi
-        set +e
         ./kube-linter $CONFIG lint ${{ inputs.directory }} --format ${{ inputs.format }} | tee ${{ inputs.output-file }}
-        exit "${PIPESTATUS[0]}"

--- a/action.yml
+++ b/action.yml
@@ -34,10 +34,14 @@ runs:
           Windows) OS=windows ;;
           *)       OS=linux ;;
         esac
+        RELEASE_URL='https://api.github.com/repos/stackrox/kube-linter/releases/latest'
+        if [ "${{ inputs.version }}" != "latest" ]; then
+          RELEASE_URL='https://api.github.com/repos/stackrox/kube-linter/releases/tags/${{ inputs.version }}'
+        fi
         RELEASE_INFO=$(curl --silent --show-error --fail \
           --header 'authorization: Bearer ${{ github.token }}' \
           --header 'Cache-Control: no-cache, must-revalidate' \
-          'https://api.github.com/repos/stackrox/kube-linter/releases/${{ inputs.version }}')
+          "${RELEASE_URL}")
         RELEASE_NAME=$(echo "${RELEASE_INFO}" | jq --raw-output ".name")
         LOCATION=$(echo "${RELEASE_INFO}" \
           | jq --raw-output ".assets[].browser_download_url" \

--- a/action.yml
+++ b/action.yml
@@ -11,15 +11,15 @@ inputs:
     description: 'Path to config file'
     required: false
   format:
-    description: 'Output format. Allowed values: json, plain, sarif. (default is "plain")'
+    description: 'Output format. Allowed values: json, plain, sarif. Default: "plain"'
     required: false
     default: 'plain'
   output-file:
-    description: 'Filename to store output.  Default "kubelinter.log"'
+    description: 'Filename to store output. File will be overwritten if it exists. Default: "kubelinter.log"'
     required: false
     default: 'kubelinter.log'
   version:
-    description: 'Version of kube-linter to use. Default "latest"'
+    description: 'Version of kube-linter to use. Default: "latest"'
     required: false
     default: 'latest'
 runs:
@@ -54,10 +54,6 @@ runs:
         else
           CONFIG="--config ${{ inputs.config }}"
         fi
-        if [[ "${{ inputs.format }}" == "plain" ]]; then
-          ./kube-linter $CONFIG lint ${{ inputs.directory }} 2>&1 | tee -a ${{ inputs.output-file }}
-        else
-          ./kube-linter $CONFIG lint ${{ inputs.directory }} --format ${{ inputs.format }} | tee ${{ inputs.output-file }}
-        fi
+        ./kube-linter $CONFIG lint ${{ inputs.directory }} --format ${{ inputs.format }} | tee ${{ inputs.output-file }}
         exit ${PIPESTATUS[0]}
       shell: bash

--- a/action.yml
+++ b/action.yml
@@ -34,7 +34,10 @@ runs:
           Windows) OS=windows ;;
           *)       OS=linux ;;
         esac
-        RELEASE_INFO=$(curl --silent --show-error --fail https://api.github.com/repos/stackrox/kube-linter/releases/${{ inputs.version }})
+        RELEASE_INFO=$(curl --silent --show-error --fail \
+          --header 'authorization: Bearer ${{ github.token }}' \
+          --header 'Cache-Control: no-cache, must-revalidate' \
+          'https://api.github.com/repos/stackrox/kube-linter/releases/${{ inputs.version }}')
         RELEASE_NAME=$(echo "${RELEASE_INFO}" | jq --raw-output ".name")
         LOCATION=$(echo "${RELEASE_INFO}" \
           | jq --raw-output ".assets[].browser_download_url" \

--- a/action.yml
+++ b/action.yml
@@ -11,7 +11,7 @@ inputs:
     description: 'Path to config file'
     required: false
   format:
-    description: 'Output format. Allowed values: json, plain, sarif. Default: "plain"'
+    description: 'Output format. Allowed values: sarif, plain, json. Default: "plain"'
     required: false
     default: 'plain'
   output-file:


### PR DESCRIPTION
This includes and supersedes https://github.com/stackrox/kube-linter-action/pull/6

Changes:
* Added action parameter for output format.
* Refreshed parameters info in `README.md`.
* Fixed release info caching and api throttling issue.
* Fixed the way kube-linter release version is looked up.
* Extended self-tests.
* Other minor fixes.

Testing done: relying on CI.