### PR TITLE
fix: pass authorization header only if specified

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -44,7 +44,7 @@ runs:
         # Caching is disabled in order not to receive stale responses from Varnish cache fronting GitHub API.
         RELEASE_HEADER=''
         if [ ! -z "${{github.token}}" ]; then
-          RELEASE_HEADER="--header 'authorization: Bearer ${{ github.token }}'"
+          RELEASE_HEADER=("--header" "'authorization: Bearer ${{ github.token }}'")
         fi
         RELEASE_INFO="$(curl --silent --show-error --fail \
           --header 'Cache-Control: no-cache, must-revalidate' \

--- a/action.yml
+++ b/action.yml
@@ -42,9 +42,13 @@ runs:
         # in order to increase the limit of 60 requests per hour per IP address to a higher value that's also counted
         # per GitHub account.
         # Caching is disabled in order not to receive stale responses from Varnish cache fronting GitHub API.
+        RELEASE_HEADER=''
+        if [ ! -z "${{github.token}}" ]; then
+          RELEASE_HEADER="--header 'authorization: Bearer ${{ github.token }}'"
+        fi
         RELEASE_INFO="$(curl --silent --show-error --fail \
-          --header 'authorization: Bearer ${{ github.token }}' \
           --header 'Cache-Control: no-cache, must-revalidate' \
+          ${RELEASE_HEADER} \
           "${RELEASE_URL}")"
         RELEASE_NAME="$(echo "${RELEASE_INFO}" | jq --raw-output ".name")"
         LOCATION="$(echo "${RELEASE_INFO}" \


### PR DESCRIPTION
* [Act](https://github.com/nektos/act) is a project which allows users to locally test GitHub actions before deploying them. This makes it easier for users to validate that actions work as intended.
* Currently, running `kube-linter-action` locally results in a `401` error when trying to fetch the release because we pass an empty authorization header.
* This PR fixes this by conditionally passing this header.