### PR TITLE
support setting token for github enterprise

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,3 +36,4 @@ The workflow will fail if kube-linter detects issues. You'll find issues in the 
 | `output-file` | (optional) | Path to a file where kube-linter output will be stored. Default is `kube-linter.log`. File will be overwritten if it exists. |
 | `version` | (optional) | kube-linter release version to use, e.g. "0.2.4". The latest available version is used by default. |
 | `fail-on-invalid-resource` | (optional) | Set `true` to error out when we have an invalid resource. |
+| `token` | (optional) | Token to use when pulling release info from github.com |

--- a/action.yml
+++ b/action.yml
@@ -26,6 +26,10 @@ inputs:
     description: 'Error out when we have an invalid resource. Default: false'
     required: false
     default: 'false'
+  token:
+    description: 'Used to pull release info from GitHub. Does not need to be supplied on github.com.'
+    required: false
+    default: ${{ github.server_url == 'https://github.com' && github.token || '' }}
 runs:
   using: "composite"
   steps:
@@ -46,8 +50,12 @@ runs:
         # in order to increase the limit of 60 requests per hour per IP address to a higher value that's also counted
         # per GitHub account.
         # Caching is disabled in order not to receive stale responses from Varnish cache fronting GitHub API.
+        AUTH_HEADER=""
+        if [[ "${{ inputs.token }}" != "" ]]; then
+          AUTH_HEADER="Authorization: Bearer ${{ inputs.token }}"
+        fi
         RELEASE_INFO="$(curl --silent --show-error --fail \
-          --header 'authorization: Bearer ${{ github.token }}' \
+          --header "$AUTH_HEADER" \
           --header 'Cache-Control: no-cache, must-revalidate' \
           "${RELEASE_URL}")"
         RELEASE_NAME="$(echo "${RELEASE_INFO}" | jq --raw-output ".name")"
@@ -69,11 +77,11 @@ runs:
         else
           CONFIG="--config ${{ inputs.config }}"
         fi
-        
+
         if [[ "${{ inputs.fail-on-invalid-resource }}" == "true" ]]; then
           FLAG_ARGS="--fail-on-invalid-resource "
         else
           FLAG_ARGS=""
         fi
-        
+
         ./kube-linter $CONFIG lint "${{ inputs.directory }}" --format "${{ inputs.format }}" $FLAG_ARGS | tee "${{ inputs.output-file }}"


### PR DESCRIPTION
Action cannot be run on enterprise instances due to `github.token` being set as the bearer token when pulling release info from github.com.

`github.token` is still the default for actions run from github.com.
Default is empty (so anonymous) otherwise as curl ignores `--header ""`.